### PR TITLE
ci: define SDK version once in global.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.203
+          global-json-file: global.json
       - name: Clean
         run: dotnet clean ./AllMyLights.sln --configuration Release && dotnet nuget locals all --clear
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.203
+        global-json-file: global.json
     - name: Clean
       run: dotnet clean ./AllMyLights.sln --configuration Release && dotnet nuget locals all --clear 
     - name: Install dependencies

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "7.0.203",
+      "rollForward": "latestFeature"
+    }
+  }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-      "version": "7.0.203",
-      "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "7.0.203",
+    "rollForward": "latestFeature"
   }
+}


### PR DESCRIPTION
Let's keep things dry and define the dotnet SDK version only in one place